### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.1-alpine
+FROM python:3.6-buster
 WORKDIR /project
 ADD . /project
 RUN pip install -r requirements.txt


### PR DESCRIPTION
uWSGI requires a C compiler which alpine containers to not contain.
Fixing with Debian Buster as provided by Docker Hub [1]

[1] https://hub.docker.com/_/python